### PR TITLE
Update avoiding-package-lockout-in-ubuntu-1804.md

### DIFF
--- a/content/tips/avoiding-package-lockout-in-ubuntu-1804.md
+++ b/content/tips/avoiding-package-lockout-in-ubuntu-1804.md
@@ -40,6 +40,11 @@ function killService() {
     sudo systemctl stop $service
     sudo systemctl kill --kill-who=all $service
 
+    # If the service has never ran, we don't need to wait for it to die
+    if ! systemctl status "$service" | grep -q "Main PID:.*"; then
+        return 0
+    fi
+
     # Wait until the status of the service is either exited or killed.
     while ! (sudo systemctl status "$service" | grep -q "Main.*code=\(exited\|killed\)")
     do


### PR DESCRIPTION
I noticed that sometimes, some of the services have never actually ran... so by checking for `Main PID:` from the systemd status output first, we can see if they have previously been spawned.

Without this additional conditional check, the while loop will continue for ever. There may be a more elegant way to write the bash / grep... however I've already spent far too long on this problem ! :)

Thanks BTW, this page saved me a bunch of time in debugging! :)