### PR TITLE
Correct hub CLI command

### DIFF
--- a/content/tips/git-tips.md
+++ b/content/tips/git-tips.md
@@ -89,7 +89,7 @@ to the branch, or a compare view URL. You can use the excellent
 [hub](http://defunkt.io/hub/) to easily generate compare URLs for sharing:
 
 ```bash
-(master) $ git compare master..feature/masquerading
+(master) $ hub compare master..feature/masquerading
 ```
 
 This will open your default browser on the compare URL, which you can then copy


### PR DESCRIPTION
The compare command is a `hub` command not a `git` command